### PR TITLE
Sync votes for new clients

### DIFF
--- a/src/components/SessionPage.vue
+++ b/src/components/SessionPage.vue
@@ -114,10 +114,12 @@ export default {
         })
       }
 
-      this.channel.trigger('client-vote', {
-        userId: this.userId,
-        points: this.vote
-      })
+      if (this.vote !== null) {
+        this.channel.trigger('client-vote', {
+          userId: this.userId,
+          points: this.vote
+        })
+      }
     })
 
     channel.bind('pusher:member_removed', (member) => {

--- a/src/components/SessionPage.vue
+++ b/src/components/SessionPage.vue
@@ -113,6 +113,11 @@ export default {
           vote: member.info.vote
         })
       }
+
+      this.channel.trigger('client-vote', {
+        userId: this.userId,
+        points: this.vote
+      })
     })
 
     channel.bind('pusher:member_removed', (member) => {


### PR DESCRIPTION
This resolves #1 by making it so when a new client joins the room, all clients will "vote" again and just resend their current vote (assuming they have a vote other than null). This way the new client receives all the votes and immediately gets in sync.