### PR TITLE
Add custom 404 page

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow: /s
 Disallow: /s/
+Disallow: /404

--- a/src/components/NotFound.vue
+++ b/src/components/NotFound.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="h-screen flex flex-col justify-center">
+    <h1 class="flex justify-center">
+      <img src="/static/ellipsis.svg" class="mr-2 h-8" />
+      <span class="text-3xl text-black font-normal">404</span>
+    </h1>
+
+    <router-link to="/" tag="button" class="mt-8 btn btn-blue self-center no-underline">start a new session</router-link>
+
+    <form class="mt-8 self-center flex">
+      <input type="text" id="room" class="login-input w-48 rounded-r-none" v-model="id" placeholder="session-id">
+      <router-link v-if="id && id.trim().length > 0" :to="{ name: 'SessionPage', params: { id: id.trim() } }" tag="button" class="btn btn-blue no-underline rounded-l-none">join</router-link>
+      <button v-else class="btn btn-blue opacity-50 hover:bg-blue cursor-not-allowed rounded-l-none" disabled>join</button>
+    </form>
+  </div>
+</template>
+
+<script>
+import UserItem from './UserItem'
+
+export default {
+  components: {
+    UserItem
+  },
+  data () {
+    return {
+      id: ''
+    }
+  }
+}
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import Router from 'vue-router'
 import LoginPage from '@/components/LoginPage'
 import SessionPage from '@/components/SessionPage'
+import NotFound from '@/components/NotFound'
 
 Vue.use(Router)
 
@@ -18,6 +19,15 @@ export default new Router({
       name: 'SessionPage',
       component: SessionPage,
       props: true
+    },
+    {
+      path: '/404',
+      name: '404',
+      component: NotFound
+    },
+    {
+      path: '*',
+      redirect: '/404'
     }
   ]
 })

--- a/test/unit/specs/NotFound.spec.js
+++ b/test/unit/specs/NotFound.spec.js
@@ -1,0 +1,83 @@
+import { shallowMount, RouterLinkStub } from '@vue/test-utils'
+import NotFound from '@/components/NotFound'
+
+describe('NotFound.vue', () => {
+  it ('should render a button to the home page', () => {
+    const wrapper = shallowMount(NotFound, {
+      stubs: {
+        RouterLink: RouterLinkStub
+      }
+    })
+
+    expect(wrapper.findAll(RouterLinkStub).at(0).props().to).toEqual('/')
+  })
+
+  it('should render disabled button without session', () => {
+    const wrapper = shallowMount(NotFound, {
+      stubs: {
+        RouterLink: RouterLinkStub
+      }
+    })
+
+    expect(wrapper.findAll('button').length).toBe(2)
+    expect(wrapper.find('button:disabled').exists()).toBe(true)
+  })
+
+  it('should render disabled button with empty string session', () => {
+    const wrapper = shallowMount(NotFound, {
+      stubs: {
+        RouterLink: RouterLinkStub
+      }
+    })
+    wrapper.find('input#room').setValue('   ')
+
+    expect(wrapper.findAll('button').length).toBe(2)
+    expect(wrapper.find('button:disabled').exists()).toBe(true)
+  })
+
+  it('should render enabled button with session', () => {
+    const wrapper = shallowMount(NotFound, {
+      stubs: {
+        RouterLink: RouterLinkStub
+      }
+    })
+    wrapper.find('input#room').setValue('123')
+
+    expect(wrapper.findAll('button').length).toBe(2)
+    expect(wrapper.find('button:disabled').exists()).toBe(false)
+  })
+
+  it('should link the user to the session they typed in', () => {
+    const wrapper = shallowMount(NotFound, {
+      stubs: {
+        RouterLink: RouterLinkStub
+      }
+    })
+    wrapper.find('input#room').setValue('123')
+
+    expect(wrapper.findAll(RouterLinkStub).at(1).props().to)
+    .toEqual({
+      name: 'SessionPage',
+      params: {
+        id: '123'
+      }
+    })
+  })
+
+  it('should trim the session the user typed in', () => {
+    const wrapper = shallowMount(NotFound, {
+      stubs: {
+        RouterLink: RouterLinkStub
+      }
+    })
+    wrapper.find('input#room').setValue('    123  ')
+
+    expect(wrapper.findAll(RouterLinkStub).at(1).props().to)
+    .toEqual({
+      name: 'SessionPage',
+      params: {
+        id: '123'
+      }
+    })
+  })
+})


### PR DESCRIPTION
This resolves #13 by adding a custom 404 page that allows the user to go back to the home page or directly join a session by typing in the room ID.